### PR TITLE
Refactor/update neon 0.10 fix tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,14 @@ pub use de::from_value_opt;
 pub use errors::MapErrIntoThrow;
 pub use ser::to_value;
 
+///
+#[doc = include_str!("../readme.md")]
+///
+/// NOTE This private method is just so we include the examples from the 'readme.md' in the doc-test
+/// pass to make sure they still compile.
+#[allow(dead_code)]
+fn check_readme() {}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,12 +23,12 @@ macro_rules! export {
 
                     $(
                         let $arg = cx.argument_opt(_arg_index);
-                        let $arg: $atype = $crate::from_value_opt(&mut cx, $arg)?;
+                        let $arg: $atype = $crate::from_value_opt(&mut cx, $arg).map_err_into_throw(&mut cx)?;
                         _arg_index += 1;
                     )*
 
                     let result = $name($( $arg ),*);
-                    let handle = $crate::to_value(&mut cx, &result)?;
+                    let handle = $crate::to_value(&mut cx, &result).map_err_into_throw(&mut cx)?;
                     Ok(handle)
                 })?;
             )*

--- a/test/native/Cargo.toml
+++ b/test/native/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["dylib"]
 neon-build = "0.7.0"
 
 [dependencies]
-neon = "0.7"
+neon = { version = "0.10.0-alpha.2", default-features = false, features = ["default-panic-hook", "napi-6", "try-catch-api", "event-queue-api"] }
 neon-serde = { path = "../../" }
 serde_derive = "1.0.106"
 serde = "1.0.106"

--- a/test_macro/__tests__/macros.js
+++ b/test_macro/__tests__/macros.js
@@ -25,7 +25,7 @@ describe('macro functions', () => {
         native.expect_buffer_only(new Buffer('000011110000', 'hex'))
         expect(() => {
           native.expect_buffer_only([1, 2, 3, 4])
-        }).toThrow(/failed downcast to Buffer/)
+        }).toThrow(/failed to downcast any to Buffer/)
 
         native.expect_array([0,0,0,0])
     })

--- a/test_macro/native/Cargo.toml
+++ b/test_macro/native/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["dylib"]
 neon-build = "0.7.0"
 
 [dependencies]
-neon = "0.7.0"
+neon = { version = "0.10.0-alpha.2", default-features = false, features = ["default-panic-hook", "napi-6", "try-catch-api", "event-queue-api"] }
 neon-serde = { path = "../../" }
 serde_derive = "1.0.106"
 serde = "1.0.106"

--- a/test_macro/native/src/lib.rs
+++ b/test_macro/native/src/lib.rs
@@ -5,6 +5,7 @@ extern crate neon_serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_bytes;
+use neon_serde::MapErrIntoThrow;
 
 #[derive(Deserialize)]
 struct User {


### PR DESCRIPTION
Description: 

- Fix the `test` and `test_macro` native tests
- Fix the `export!` macro
- Rearranged `readme.md`  so the rust code blocks can be included as doc-tests